### PR TITLE
feat: local ref/build of orbitdb in pin server and 3boxjs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "3box-graphql"]
 	path = 3box-graphql
 	url = https://github.com/3box/3box-graphql
+[submodule "orbit-db"]
+	path = orbit-db
+	url = https://github.com/orbitdb/orbit-db.git

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       - ./3box-js/webpack.dev.config.js:/3box-js/webpack.dev.config.js
       - ./3box-js/.babelrc:/3box-js/.babelrc
       - ./3box-js/example:/3box-js/example
+      - ./orbit-db:/3box-js/node_modules/orbit-db
     ports:
       - "30000:30000"
     environment:
@@ -29,6 +30,7 @@ services:
       dockerfile: Dockerfile.pinning
     volumes:
       - ./3box-pinning-server/src:/3box-pinning-server/src
+      - ./orbit-db:/3box-pinning-server/node_modules/orbit-db
     ports:
       - 8081:8081
       - 4002:4002


### PR DESCRIPTION
Don't need to merge. Want to make this option, but not a default as done here. 

But this config add orbit-db as a submodule so that you can edit code there, and it copy that ref into the 3boxjs and pinning containers so that you get that local orbitdb code in those builds for testing and debugging. 

You can turn on extra logging in orbit db by changing `Logger.setLogLevel('ERROR')` to ` Logger.setLogLevel('DEBUG')` in some of the files in the src folder in orbitdb.  cc @oed 